### PR TITLE
Resolve 2 mismatch stubbings in EqualsAndHashCodeTest.java

### DIFF
--- a/src/test/java/com/lazerycode/selenium/util/EqualsAndHashCodeTest.java
+++ b/src/test/java/com/lazerycode/selenium/util/EqualsAndHashCodeTest.java
@@ -86,7 +86,7 @@ public class EqualsAndHashCodeTest {
     public void equalsDriver() {
         Capabilities mockedCapabilities = mock(Capabilities.class);
         when(mockedCapabilities.getBrowserName()).thenReturn(BrowserType.GOOGLECHROME);
-        when(mockedCapabilities.getCapability(PLATFORM_NAME)).thenReturn(Platform.YOSEMITE);
+        when(mockedCapabilities.getCapability("automationName")).thenReturn(Platform.YOSEMITE);
 
         RemoteWebDriver mockedWebDriver = mock(RemoteWebDriver.class);
         when(mockedWebDriver.getCapabilities()).thenReturn(mockedCapabilities);
@@ -104,7 +104,7 @@ public class EqualsAndHashCodeTest {
     public void notEqualsDriver() {
         Capabilities mockedWebDriverCapabilities = mock(Capabilities.class);
         when(mockedWebDriverCapabilities.getBrowserName()).thenReturn(BrowserType.GOOGLECHROME);
-        when(mockedWebDriverCapabilities.getCapability(PLATFORM_NAME)).thenReturn(Platform.YOSEMITE);
+        when(mockedWebDriverCapabilities.getCapability("automationName")).thenReturn(Platform.YOSEMITE);
 
         RemoteWebDriver mockedWebDriver = mock(RemoteWebDriver.class);
         when(mockedWebDriver.getCapabilities()).thenReturn(mockedWebDriverCapabilities);


### PR DESCRIPTION
We are researchers and analyzed the test doubles (mocks) in the test code of the project. In our analysis of the project, we observed that

+ 2 stubbings for the`getCapability` method are stubbed with argument "platformName", but in actual execution, they are called with argument "automationName", resulting in mismatched stubbings. These mismatches occur in tests `notEqualsDriver` and `equalsDriver`.

In this pull request, we propose a solution to resolve the mismatch stubbing.

Mismatched stubbing occurs when a mocked method is stubbed with specific arguments in a test but later invoked with different arguments in the code, potentially causing unexpected behavior. Mockito recommends addressing these issues, (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/PotentialStubbingProblem.html)